### PR TITLE
fix maxThreads crash

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -765,7 +765,11 @@ class Backend(QObject):
 
     @pyqtProperty(int, notify=updated)
     def maxThreads(self):
-        return len(os.sched_getaffinity(0))
+        try:
+            n_threads = len(os.sched_getaffinity(0))
+        except AttributeError:
+            n_threads = os.cpu_count()
+        return n_threads
 
     ### Slots
 


### PR DESCRIPTION
fix issues [#7](https://github.com/arenatemp/sd-tagging-helper/issues/7)

Fix the windows system runs programs that crash in `os.sched_getaffinity(0)`. 


